### PR TITLE
Enforce Jira ticket in PR branch name to prevent merging without Jira reference

### DIFF
--- a/.github/workflows/enforce-jira-ticket.yml
+++ b/.github/workflows/enforce-jira-ticket.yml
@@ -1,0 +1,19 @@
+name: Enforce Jira Ticket in PR Branch Name
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  check-jira-ticket:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR branch name for Jira ticket
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const jiraPattern = /[A-Z]{2,}-\d+/;
+            const branch = context.payload.pull_request.head.ref;
+            if (!jiraPattern.test(branch)) {
+              core.setFailed(`Branch name '${branch}' does not contain a Jira ticket (e.g., ABC-123). Please include a Jira ticket in your branch name.`);
+            }


### PR DESCRIPTION
This PR adds a GitHub Action workflow that blocks PRs from being merged unless the branch name contains a Jira ticket (e.g., ABC-123). This enforces the policy described in issue #28.